### PR TITLE
Reload on change support

### DIFF
--- a/guard-redis.gemspec
+++ b/guard-redis.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_dependency 'guard', '>= 0.4.0'
-  s.add_dependency 'redis', '> 2.2.2'
+  s.add_dependency 'redis', '>= 2.2.2'
 
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rspec',   '~> 2.6'

--- a/lib/guard/redis.rb
+++ b/lib/guard/redis.rb
@@ -4,20 +4,20 @@ require 'guard/guard'
 module Guard
   class Redis < Guard
     def start
-      puts "Starting Redis on port #{port}"
+      UI.info "Starting Redis on port #{port}..."
       @pid = nil
       IO.popen("#{executable} -", 'w+') do |server|
         @pid = server.pid
         server.write(config)
         server.close_write
       end
-      puts "Redis is running with PID #{pid}"
+      UI.info "Redis is running with PID #{pid}"
       last_operation_succeeded?
     end
 
     def stop
       if pid
-        puts "Sending TERM signal to Redis (#{pid})"
+        UI.info "Sending TERM signal to Redis (#{pid})"
         Process.kill("TERM", pid)
         @pid = nil
         true
@@ -25,8 +25,10 @@ module Guard
     end
 
     def reload
+      UI.info "Reloading Redis..."
       stop
       start
+      UI.info "Redis successfully restarted."
     end
 
     def run_all
@@ -34,7 +36,7 @@ module Guard
     end
 
     def run_on_change(paths)
-      true
+      reload if reload_on_change?
     end
 
     def pidfile_path
@@ -65,6 +67,10 @@ END
 
     def last_operation_succeeded?
       $?.success?
+    end
+
+    def reload_on_change?
+      options.fetch(:reload_on_change) { false }
     end
   end
 end

--- a/spec/guard/redis/redis_spec.rb
+++ b/spec/guard/redis/redis_spec.rb
@@ -6,7 +6,7 @@ describe Guard::Redis do
 
   describe "#start" do
     before(:each) do
-      guard.stub(:last_operation_succeeded?).and_return(true) 
+      guard.stub(:last_operation_succeeded?).and_return(true)
     end
 
     it "calls IO.popen and passes in the executable" do
@@ -54,6 +54,20 @@ describe Guard::Redis do
     end
   end
 
+  describe "#run_on_change" do
+    it "reloads the process if specifed in options" do
+      guard.stub(:reload_on_change?).and_return(true)
+      guard.should_receive(:reload).once
+      guard.run_on_change([])
+    end
+
+    it "does not reload the process if specifed in options" do
+      guard.stub(:reload_on_change?).and_return(false)
+      guard.should_receive(:reload).never
+      guard.run_on_change([])
+    end
+  end
+
   describe "options" do
     describe "executable" do
       it "fetches the default executable if no option was passed in" do
@@ -85,6 +99,17 @@ describe Guard::Redis do
       it "fetches the overridden pidfile path if one was provided" do
         subject = described_class.new([], { :pidfile => "/var/pid/redis.pid" })
         subject.pidfile_path.should == "/var/pid/redis.pid"
+      end
+    end
+
+    describe "reload_on_change" do
+      it "fetches the default reload_on_change if no options was passed in" do
+        guard.reload_on_change?.should == false
+      end
+
+      it "fetches the overridden reload_on_change if one was provided" do
+        subject = described_class.new([], { :reload_on_change => true })
+        subject.reload_on_change?.should == true
       end
     end
   end


### PR DESCRIPTION
This allows the user to specify :reload_on_change in the options and
have Guard reload the redis process if any of the monitored files are
changed. We find this useful for local development when we're changing
code that affects cached items.

Other updates:
- Allow Redis 2.2.2, which is required by version 1.0.0 of the
  redis-store gem (the only version compatible with Rails 3.1.3). As far
  as I can tell there's no real dependency on this gem disallowing Redis
  2.2.2.
- Use Guard's UI.info instead of puts for prettier output in the Guard
  console session.
