### PR TITLE
Add support for shutdown retries and Redis logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,16 @@ It takes several options related to its configuration.
 :pidfile => "/var/pid/redis.pid"                   # Set a custom path the where the pidfile is written
 :reload_on_change => false                         # Reload Redis if any of the specified files change. Note that you
                                                    # must specify this option in addition to passing a block to Guard.
+:capture_logging => true                           # Enables logging to :logfile
+:logfile => "log/redis_#{port}.log"                # Set a custom path where logs from Redis are written
+                                                   # Since by default the output from Redis goes to the ether, these options
+                                                   # let you redirect logging to a file to assist with debugging crashes
+:shutdown_retries => 3                             # Set a number of times to retry
+:shutdown_wait => 5                                # Set a number of seconds to wait between retries
+                                                   # Sometimes Redis takes more than a moment to shut down and you can use
+                                                   # these options to ensure it does so cleanly before reloading with :reload_on_change.
 ~~~~
 
-## Contributers
+## Contributors
 
 https://github.com/whazzmaster/guard-redis/graphs/contributors

--- a/lib/guard/redis/templates/Guardfile
+++ b/lib/guard/redis/templates/Guardfile
@@ -1,4 +1,4 @@
-# Possible options are :port, :executable, :pidfile, and :reload_on_change
+# Possible options are :port, :executable, :pidfile, :reload_on_change, :capture_logging, :logfile, :shutdown_retries, :shutdown_wait
 
 # Default implementation - starts Redis on standard port and stops on exit
 guard 'redis'
@@ -7,5 +7,11 @@ guard 'redis'
 # Redis when any Ruby file changes in the app, lib, or config directories.
 #
 # guard 'redis', :executable => 'redis-server', :pidfile => 'tmp/pids/redis.pid', :port => 6379, :reload_on_change => true do
+#   watch(/^(app|lib|config)\/.*\.rb$/)
+# end
+
+# Same as above - also enable Redis logging and 3 shutdown retries spaced 5 seconds apart
+#
+# guard 'redis', :executable => 'redis-server', :pidfile => 'tmp/pids/redis.pid', :port => 6379, :reload_on_change => true, :capture_logging => true, :logfile => 'log/redis.log', :shutdown_retries => 3, :shutdown_wait => 5 do
 #   watch(/^(app|lib|config)\/.*\.rb$/)
 # end

--- a/spec/guard/redis/redis_spec.rb
+++ b/spec/guard/redis/redis_spec.rb
@@ -112,5 +112,64 @@ describe Guard::Redis do
         subject.reload_on_change?.should == true
       end
     end
+
+    describe "capture_logging" do
+      it "fetches the default capture_logging if no options was passed in" do
+        guard.capture_logging?.should == false
+      end
+
+      it "fetches the overridden capture_logging if one was provided" do
+        subject = described_class.new([], { :capture_logging => true })
+        subject.capture_logging?.should == true
+      end
+    end
+
+    describe "logfile" do
+      it "fetches the default logfile if no options was passed in" do
+        guard.logfile.should == "stdout"
+      end
+
+      it "fetches the overridden logfile if one was provided" do
+        subject = described_class.new([], { :logfile => "log/redis.log" })
+        subject.logfile.should == "log/redis.log"
+      end
+
+      it "fetches the standard logfile if capture_logging is enabled" do
+        subject = described_class.new([], { :capture_logging => true })
+        subject.logfile.should == "log/redis_6379.log"
+      end
+
+      it "fetches the logfile with port if set and capture_logging is enabled" do
+        subject = described_class.new([], { :capture_logging => true, :port => 9999 })
+        subject.logfile.should == "log/redis_9999.log"
+      end
+
+      it "should appear in the config if capture_logging is enabled " do
+        subject = described_class.new([], { :capture_logging => true, :logfile => 'log/redis.log' })
+        subject.config.should == "daemonize yes\npidfile /tmp/redis.pid\nport 6379\nlogfile log/redis.log"
+      end
+    end
+
+    describe "shutdown_retries" do
+      it "fetches the default shutdown_retries if no options was passed in" do
+        guard.shutdown_retries.should == 0
+      end
+
+      it "fetches the overridden shutdown_retries if one was provided" do
+        subject = described_class.new([], { :shutdown_retries => 3 })
+        subject.shutdown_retries.should == 3
+      end
+    end
+
+    describe "shutdown_wait" do
+      it "fetches the default shutdown_wait if no options was passed in" do
+        guard.shutdown_wait.should == 0
+      end
+
+      it "fetches the overridden shutdown_retries if one was provided" do
+        subject = described_class.new([], { :shutdown_wait => 5 })
+        subject.shutdown_wait.should == 5
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows the user to set new options for handling Redis shutdown retries
and logging. The shutdown options resolve an issue I was encountering
with :reload_on_change where the shutdown was asynchronous and wouldn't
always be finished by the time the start command was received, causing
Redis to not be reloaded. The logging options were added as
part of my efforts to debug the shutdown issue.

:shutdown_retries => 0 - Number of times to check whether the shutdown
has finished before giving up
:shutdown_wait => 0 - Number of seconds to wait between retries
:capture_logging => false - Enable to redirect Redis logging to a file
:logfile => "log/redis_#{port}.log" - The log file to write when
:capture_logging is enabled
